### PR TITLE
chore: replace old site domain and contact email

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-contact@sanidhy.me.
+sanidhyyy@gmail.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 This project and everyone participating in it is governed by the
 [Portfolio Code of Conduct](https://github.com/sanidhyy/portfolioblob/master/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
-to <contact@sanidhy.me>.
+to <sanidhyyy@gmail.com>.
 
 
 ## I Have a Question
@@ -89,7 +89,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 <!-- omit in toc -->
 #### How Do I Submit a Good Bug Report?
 
-> You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead sensitive bugs must be sent by email to <contact@sanidhy.me>.
+> You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead sensitive bugs must be sent by email to <sanidhyyy@gmail.com>.
 <!-- You may add a PGP key to allow the messages to be sent encrypted as well. -->
 
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Github commits](https://flat.badgen.net/github/commits/sanidhyy/portfolio?icon=github&color=black&scale=1.01)](https://github.com/sanidhyy/portfolio/commits "Github commits")
 [![GitHub issues](https://flat.badgen.net/github/issues/sanidhyy/portfolio?icon=github&color=black&scale=1.01)](https://github.com/sanidhyy/portfolio/issues "GitHub issues")
 [![GitHub pull requests](https://flat.badgen.net/github/prs/sanidhyy/portfolio?icon=github&color=black&scale=1.01)](https://github.com/sanidhyy/portfolio/pulls "GitHub pull requests")
-[![Vercel status](https://img.shields.io/badge/Vercel-000000?style=for-the-badge&logo=vercel&logoColor=white)](https://www.sanidhy.me/ "Vercel status")
+[![Vercel status](https://img.shields.io/badge/Vercel-000000?style=for-the-badge&logo=vercel&logoColor=white)](https://www.sanidhyy.name/ "Vercel status")
 
 <!-- Table of Contents -->
 <details>
@@ -152,7 +152,7 @@ NEXT_PUBLIC_GOOGLE_VERIFICATION_KEY=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 ## :wrench: Stats
 
-[![Stats for My portfolio](/.github/images/stats.svg "Stats for My portfolio")](https://pagespeed.web.dev/analysis?url=https://www.sanidhy.me/ "Stats for My portfolio")
+[![Stats for My portfolio](/.github/images/stats.svg "Stats for My portfolio")](https://pagespeed.web.dev/analysis?url=https://www.sanidhyy.name/ "Stats for My portfolio")
 
 ## :raised_hands: Contribute
 

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -42,7 +42,7 @@ export const EXTRA_LINKS = {
   github: "https://github.com/sanidhyy",
   resume: "/resume.pdf",
   source_code: "https://github.com/sanidhyy/portfolio",
-  email: "sanidhya.verma12345@gmail.com",
+  email: "sanidhyyy@gmail.com",
 } as const;
 
 // Data for work experience

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "author": {
     "name": "Sanidhya Kumar Verma",
-    "email": "sanidhya.verma12345@gmail.com",
+    "email": "sanidhyyy@gmail.com",
     "url": "https://github.com/sanidhyy"
   },
   "description": "Sanidhya is a full-stack developer with 4 years of experience.",
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/sanidhyy/portfolio#readme",
   "bugs": {
     "url": "https://github.com/sanidhyy/portfolio/issues",
-    "email": "sanidhya.verma12345@gmail.com"
+    "email": "sanidhyyy@gmail.com"
   },
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- site links now use sanidhyy.name; contact addresses now use sanidhyyy@gmail.com

## Changes
- `CODE_OF_CONDUCT.md`: contact@sanidhy.me -> sanidhyyy@gmail.com
- `CONTRIBUTING.md`: contact@sanidhy.me -> sanidhyyy@gmail.com
- `README.md`: sanidhy.me -> sanidhyy.name
- `constants/index.ts`: sanidhya.verma12345@gmail.com -> sanidhyyy@gmail.com
- `package.json`: sanidhya.verma12345@gmail.com -> sanidhyyy@gmail.com
